### PR TITLE
Scan single-character, unambiguous tokens

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,0 +1,66 @@
+mod token;
+
+use token::{Token, Type};
+
+struct Scanner;
+
+impl Scanner {
+    fn scan_tokens(source: &str) -> Vec<Token> {
+        let mut tokens: Vec<Token> = vec![];
+
+        for &byte in source.as_bytes() {
+            let token = Self::identify_token(byte);
+            tokens.push(token);
+        }
+
+        tokens
+    }
+
+    fn identify_token(byte: u8) -> Token {
+        use Type::*;
+
+        match &[byte] {
+            b"(" => Token { r#type: LeftParen },
+            b")" => Token { r#type: RightParen },
+            b"{" => Token { r#type: LeftBrace },
+            b"}" => Token { r#type: RightBrace },
+            b"," => Token { r#type: Comma },
+            b"." => Token { r#type: Dot },
+            b"-" => Token { r#type: Minus },
+            b"+" => Token { r#type: Plus },
+            b";" => Token { r#type: Semicolon },
+            b"*" => Token { r#type: Star },
+            _ => todo!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::token::Type::*;
+    use super::*;
+
+    #[test]
+    fn scans_simple_unnambiguous_tokens() {
+        let code = "(){},.-+;*";
+
+        let tokens = Scanner::scan_tokens(code);
+
+        assert_eq!(
+            tokens,
+            &[
+                Token { r#type: LeftParen },
+                Token { r#type: RightParen },
+                Token { r#type: LeftBrace },
+                Token { r#type: RightBrace },
+                Token { r#type: Comma },
+                Token { r#type: Dot },
+                Token { r#type: Minus },
+                Token { r#type: Plus },
+                Token { r#type: Semicolon },
+                Token { r#type: Star },
+            ],
+            r#"Did not scan "(){{}},.-+;*""#
+        )
+    }
+}

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -1,4 +1,3 @@
-#[derive(Debug)]
 pub(crate) struct Token {
     pub(crate) r#type: Type,
 }
@@ -6,6 +5,12 @@ pub(crate) struct Token {
 impl PartialEq for Token {
     fn eq(&self, other: &Self) -> bool {
         self.r#type == other.r#type
+    }
+}
+
+impl std::fmt::Debug for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "⟨{:?}⟩", self.r#type)
     }
 }
 

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -1,0 +1,24 @@
+#[derive(Debug)]
+pub(crate) struct Token {
+    pub(crate) r#type: Type,
+}
+
+impl PartialEq for Token {
+    fn eq(&self, other: &Self) -> bool {
+        self.r#type == other.r#type
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Type {
+    LeftParen,
+    RightParen,
+    LeftBrace,
+    RightBrace,
+    Comma,
+    Dot,
+    Minus,
+    Plus,
+    Semicolon,
+    Star,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-mod lox;
+mod interpreter;


### PR DESCRIPTION
The scanner will be able to identify tokens that can be identified by their single-character lexeme, no matter what character comes next.

I also implemented `Debug` for `Token`, so when a test fails, it prints the expected and the actual tokens in a readable way, like `[⟨Plus⟩, ⟨Semicolon⟩]`.