### PR TITLE
Scan ambiguous tokens

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -199,7 +199,7 @@ mod tests {
         }
 
         #[test]
-        pub(crate) fn scans_line_after_comment() {
+        fn scans_line_after_comment() {
             let code = r#"
             + -
             // This is a comment!

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -8,18 +8,39 @@ impl Scanner {
     fn scan_tokens(source: &str) -> Vec<Token> {
         let mut tokens: Vec<Token> = vec![];
 
-        for &byte in source.as_bytes() {
-            let token = Self::identify_token(byte);
-            tokens.push(token);
+        let mut should_skip_iteration = false;
+        for (i, byte) in source.as_bytes().iter().enumerate() {
+            if should_skip_iteration {
+                should_skip_iteration = false;
+                continue;
+            }
+
+            let next_byte = source.as_bytes().get(i + 1);
+            let token = Self::identify_token(*byte, next_byte);
+
+            match token {
+                Token { r#type: Type::Whitespace } => continue,
+                token => {
+                    if token.is_compound() {
+                        should_skip_iteration = true;
+                    }
+                    tokens.push(token);
+                }
+            }
+
         }
 
         tokens
     }
 
-    fn identify_token(byte: u8) -> Token {
+    fn identify_token(byte: u8, next_byte: Option<&u8>) -> Token {
         use Type::*;
 
         match &[byte] {
+            b" "
+            | b"\t"
+            | b"\r"
+            | b"\n" => Token { r#type: Whitespace },
             b"(" => Token { r#type: LeftParen },
             b")" => Token { r#type: RightParen },
             b"{" => Token { r#type: LeftBrace },
@@ -30,8 +51,29 @@ impl Scanner {
             b"+" => Token { r#type: Plus },
             b";" => Token { r#type: Semicolon },
             b"*" => Token { r#type: Star },
-            _ => todo!(),
+            b"!" => decide_token(Bang, BangEqual, next_byte),
+            b"=" => decide_token(Equal, EqualEqual, next_byte),
+            b">" => decide_token(Greater, GreaterEqual, next_byte),
+            b"<" => decide_token(Less, LessEqual, next_byte),
+            _ => todo!("Unexpected lexeme {:#?}", std::str::from_utf8(&[byte])),
         }
+    }
+}
+
+/// If `next_byte` is `b"="`, then returns `compound_type`,
+/// else returns `simple_type`
+///
+/// # Note
+/// Not generalized for any two tokens yet
+fn decide_token(simple_type: Type, compound_type: Type, next_byte: Option<&u8>) -> Token {
+    match next_byte {
+        Some(&byte) => {
+            match &[byte] {
+                b"=" => Token { r#type: compound_type },
+                _ => Token { r#type: simple_type },
+            }
+        },
+        None => Token { r#type: simple_type },
     }
 }
 
@@ -61,6 +103,53 @@ mod tests {
                 Token { r#type: Star },
             ],
             r#"Did not scan "(){{}},.-+;*""#
+        )
+    }
+
+    #[test]
+    fn scans_ambiguous_tokens() {
+        let code = "!= ! == = > >= < <=";
+
+        let tokens = Scanner::scan_tokens(code);
+
+        assert_eq!(
+            tokens,
+            &[
+                Token { r#type: BangEqual },
+                Token { r#type: Bang },
+                Token { r#type: EqualEqual },
+                Token { r#type: Equal },
+                Token { r#type: Greater },
+                Token { r#type: GreaterEqual },
+                Token { r#type: Less },
+                Token { r#type: LessEqual },
+            ],
+            r#"Did not scan "!= ! == = > >= < <=""#
+        )
+    }
+
+    #[test]
+    fn test_different_spacing() {
+        let code = "
+            (+ -\t*
+            =         )
+            }\n{
+        ";
+
+        let tokens = Scanner::scan_tokens(code);
+
+        assert_eq!(
+            tokens,
+            &[
+                Token { r#type: LeftParen },
+                Token { r#type: Plus },
+                Token { r#type: Minus },
+                Token { r#type: Star },
+                Token { r#type: Equal },
+                Token { r#type: RightParen },
+                Token { r#type: RightBrace },
+                Token { r#type: LeftBrace },
+            ],
         )
     }
 }

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -59,5 +59,7 @@ pub(crate) enum Type {
     Less,
     LessEqual,
 
+    Slash,
+    SlashSlash,  // Only for internal use
     Whitespace,  // Only for internal use
 }

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -14,6 +14,29 @@ impl std::fmt::Debug for Token {
     }
 }
 
+impl Token {
+    pub fn is_compound(&self) -> bool {
+        match self.r#type {
+            Type::LeftParen
+            | Type::RightParen
+            | Type::LeftBrace
+            | Type::RightBrace
+            | Type::Comma
+            | Type::Dot
+            | Type::Minus
+            | Type::Plus
+            | Type::Semicolon
+            | Type::Star
+            | Type::Equal
+            | Type::Bang
+            | Type::Greater
+            | Type::Less => false,
+
+            _ => true,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub(crate) enum Type {
     LeftParen,
@@ -26,4 +49,15 @@ pub(crate) enum Type {
     Plus,
     Semicolon,
     Star,
+
+    Bang,
+    BangEqual,
+    Equal,
+    EqualEqual,
+    Greater,
+    GreaterEqual,
+    Less,
+    LessEqual,
+
+    Whitespace,  // Only for internal use
 }


### PR DESCRIPTION
The scanner will be able to identify two-character tokens.

It will also ignore comments of the form `// ...`, and will scan `/` (when not an `//`)