### PR TITLE
Scan literals

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -15,23 +15,14 @@ impl Scanner<'_> {
     fn scan_tokens(&mut self) -> Vec<Token> {
         let mut tokens: Vec<Token> = vec![];
 
-        let mut should_skip_line = false;
         while !self.is_at_end() {
-            if should_skip_line {
-                if &[self.current_byte()] != b"\n" {
-                    self.advance();
-                    continue;
-                }
-                should_skip_line = false;
-            }
-
             let current_byte = self.current_byte();
             let next_byte = self.next_byte();
             let r#type = Self::identify_token_type(current_byte, next_byte);
             let token = Token { r#type };
 
             match token {
-                Token { r#type: Type::SlashSlash } => should_skip_line = true,
+                Token { r#type: Type::SlashSlash } => self.skip_current_line(),
                 Token { r#type: Type::Whitespace } => (),
                 token => {
                     if token.is_compound() {
@@ -67,6 +58,10 @@ impl Scanner<'_> {
         while !self.is_at_end() && byte != [self.current_byte()] {
             self.advance();
         }
+    }
+
+    fn skip_current_line(&mut self) {
+        self.seek(b"\n");
     }
 
     fn identify_token_type(byte: u8, next_byte: Option<&u8>) -> Type {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -16,9 +16,7 @@ impl Scanner<'_> {
         let mut tokens: Vec<Token> = vec![];
 
         while !self.is_at_end() {
-            let current_byte = self.current_byte();
-            let next_byte = self.next_byte();
-            let r#type = Self::identify_token_type(current_byte, next_byte);
+            let r#type = self.identify_token_type();
             let token = Token { r#type };
 
             match token {
@@ -64,10 +62,10 @@ impl Scanner<'_> {
         self.seek(b"\n");
     }
 
-    fn identify_token_type(byte: u8, next_byte: Option<&u8>) -> Type {
+    fn identify_token_type(&self) -> Type {
         use Type::*;
 
-        match &[byte] {
+        match &[self.current_byte()] {
             b" "
             | b"\t"
             | b"\r"
@@ -82,12 +80,12 @@ impl Scanner<'_> {
             b"+" => Plus,
             b";" => Semicolon,
             b"*" => Star,
-            b"!" => decide_token_type(Bang, (BangEqual, b"="), next_byte),
-            b"=" => decide_token_type(Equal, (EqualEqual, b"="), next_byte),
-            b">" => decide_token_type(Greater, (GreaterEqual, b"="), next_byte),
-            b"<" => decide_token_type(Less, (LessEqual, b"="), next_byte),
-            b"/" => decide_token_type(Slash, (SlashSlash, b"/"), next_byte),
-            _ => todo!("Unexpected lexeme {:#?}", std::str::from_utf8(&[byte])),
+            b"!" => decide_token_type(Bang, (BangEqual, b"="), self.next_byte()),
+            b"=" => decide_token_type(Equal, (EqualEqual, b"="), self.next_byte()),
+            b">" => decide_token_type(Greater, (GreaterEqual, b"="), self.next_byte()),
+            b"<" => decide_token_type(Less, (LessEqual, b"="), self.next_byte()),
+            b"/" => decide_token_type(Slash, (SlashSlash, b"/"), self.next_byte()),
+            _ => todo!("Unexpected lexeme {:#?}", std::str::from_utf8(&[self.current_byte()])),
         }
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -103,10 +103,10 @@ impl Scanner<'_> {
                 let number = std::str::from_utf8(&self.bytes[range]);
                 if is_f64 {
                     let n = number.unwrap().parse::<f64>().unwrap();
-                    Type::NumberLiteral(token::Literal::Float(n))
+                    Type::NumberLiteral(token::NumberLiteral::Float(n))
                 } else {
                     let n = number.unwrap().parse::<i32>().unwrap();
-                    Type::NumberLiteral(token::Literal::Integer(n))
+                    Type::NumberLiteral(token::NumberLiteral::Integer(n))
                 }
             }
             _ => todo!("Unexpected lexeme {:#?}", std::str::from_utf8(&[self.current_byte()])),
@@ -168,7 +168,7 @@ fn decide_token_type(simple_type: Type, compound_type: (Type, &[u8]), next_byte:
 #[cfg(test)]
 mod tests {
     use super::token::Type::*;
-    use crate::interpreter::token::Literal;
+    use crate::interpreter::token::NumberLiteral;
 
     use super::*;
 
@@ -386,7 +386,7 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: NumberLiteral(Literal::Integer(123)) },
+                    Token { r#type: NumberLiteral(NumberLiteral::Integer(123)) },
                 ],
             )
         }
@@ -400,11 +400,11 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: NumberLiteral(Literal::Integer(0)) },
+                    Token { r#type: NumberLiteral(NumberLiteral::Integer(0)) },
                     Token { r#type: Plus },
-                    Token { r#type: NumberLiteral(Literal::Integer(123)) },
+                    Token { r#type: NumberLiteral(NumberLiteral::Integer(123)) },
                     Token { r#type: Minus },
-                    Token { r#type: NumberLiteral(Literal::Integer(1)) },
+                    Token { r#type: NumberLiteral(NumberLiteral::Integer(1)) },
                 ],
             )
         }
@@ -422,7 +422,7 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: NumberLiteral(Literal::Float(12.3)) },
+                    Token { r#type: NumberLiteral(NumberLiteral::Float(12.3)) },
                 ],
             )
         }
@@ -436,11 +436,11 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: NumberLiteral(Literal::Integer(0)) },
+                    Token { r#type: NumberLiteral(NumberLiteral::Integer(0)) },
                     Token { r#type: Plus },
-                    Token { r#type: NumberLiteral(Literal::Float(12.3)) },
+                    Token { r#type: NumberLiteral(NumberLiteral::Float(12.3)) },
                     Token { r#type: Slash },
-                    Token { r#type: NumberLiteral(Literal::Integer(5)) },
+                    Token { r#type: NumberLiteral(NumberLiteral::Integer(5)) },
                 ],
             )
         }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -172,7 +172,7 @@ fn decide_token_type(simple_type: Type, compound_type: (Type, &[u8]), next_byte:
 #[cfg(test)]
 mod tests {
     use super::token::Type::*;
-    use crate::interpreter::token::NumberLiteral;
+    use crate::interpreter::token::*;
 
     use super::*;
 
@@ -372,7 +372,7 @@ mod tests {
                 &[
                     Token { r#type: Plus },
                     Token { r#type: Minus },
-                    Token { r#type: Error(token::Error::UnterminatedString) },
+                    Token { r#type: Error(Error::UnterminatedString) },
                 ],
             )
         }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -313,7 +313,7 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: Type::StringLiteral("This is a string!".to_string()) },
+                    Token { r#type: StringLiteral("This is a string!".to_string()) },
                 ],
             )
         }
@@ -327,11 +327,11 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: Type::Plus },
-                    Token { r#type: Type::Minus },
-                    Token { r#type: Type::StringLiteral("This is a string!".to_string()) },
-                    Token { r#type: Type::Minus },
-                    Token { r#type: Type::Plus },
+                    Token { r#type: Plus },
+                    Token { r#type: Minus },
+                    Token { r#type: StringLiteral("This is a string!".to_string()) },
+                    Token { r#type: Minus },
+                    Token { r#type: Plus },
                 ],
             )
         }
@@ -348,11 +348,11 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: Type::Plus },
-                    Token { r#type: Type::Minus },
-                    Token { r#type: Type::StringLiteral("This is a string!\n                And it is still going!".to_string()) },
-                    Token { r#type: Type::Minus },
-                    Token { r#type: Type::Plus },
+                    Token { r#type: Plus },
+                    Token { r#type: Minus },
+                    Token { r#type: StringLiteral("This is a string!\n                And it is still going!".to_string()) },
+                    Token { r#type: Minus },
+                    Token { r#type: Plus },
                 ],
             )
         }
@@ -386,7 +386,7 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: Type::NumberLiteral(Literal::Integer(123)) },
+                    Token { r#type: NumberLiteral(Literal::Integer(123)) },
                 ],
             )
         }
@@ -400,11 +400,11 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: Type::NumberLiteral(Literal::Integer(0)) },
-                    Token { r#type: Type::Plus },
-                    Token { r#type: Type::NumberLiteral(Literal::Integer(123)) },
-                    Token { r#type: Type::Minus },
-                    Token { r#type: Type::NumberLiteral(Literal::Integer(1)) },
+                    Token { r#type: NumberLiteral(Literal::Integer(0)) },
+                    Token { r#type: Plus },
+                    Token { r#type: NumberLiteral(Literal::Integer(123)) },
+                    Token { r#type: Minus },
+                    Token { r#type: NumberLiteral(Literal::Integer(1)) },
                 ],
             )
         }
@@ -422,7 +422,7 @@ mod tests {
             assert_eq!(
                 tokens,
                 &[
-                    Token { r#type: Type::NumberLiteral(Literal::Float(12.3)) },
+                    Token { r#type: NumberLiteral(Literal::Float(12.3)) },
                 ],
             )
         }

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -66,13 +66,13 @@ pub(crate) enum Type {
     Whitespace,  // Only for internal use
 
     StringLiteral(String),
-    NumberLiteral(Literal),
+    NumberLiteral(NumberLiteral),
 
     Error(Error),
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum Literal {
+pub(crate) enum NumberLiteral {
     Integer(i32),
     Float(f64),
 }

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -30,7 +30,8 @@ impl Token {
             | Type::Equal
             | Type::Bang
             | Type::Greater
-            | Type::Less => false,
+            | Type::Less
+            | Type::StringLiteral(_) => false,  // Not exactly...
 
             _ => true,
         }
@@ -62,4 +63,13 @@ pub(crate) enum Type {
     Slash,
     SlashSlash,  // Only for internal use
     Whitespace,  // Only for internal use
+
+    StringLiteral(String),
+
+    Error(Error),
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Error {
+    UnterminatedString,
 }

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -31,7 +31,8 @@ impl Token {
             | Type::Bang
             | Type::Greater
             | Type::Less
-            | Type::StringLiteral(_) => false,  // Not exactly...
+            | Type::StringLiteral(_)            // Not exactly...
+            | Type::NumberLiteral(_) => false,  // Not exactly...
 
             _ => true,
         }
@@ -65,8 +66,15 @@ pub(crate) enum Type {
     Whitespace,  // Only for internal use
 
     StringLiteral(String),
+    NumberLiteral(Literal),
 
     Error(Error),
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Literal {
+    Integer(i32),
+    Float(f64),
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
The scanner will be able to scan string and number literals.

The scanner now works similarly to a stream.

I used `i32` and `f64` to make it equivalent to Java's `int` and `double` respectively.