### PR TITLE
Scan identifiers

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -53,7 +53,8 @@ impl Scanner<'_> {
         self.position += 1;
     }
 
-    /// Makes `self.position` be above the first occurrence of some byte in `bytes`.
+    /// Makes `self.position` be above the first occurrence of `byte` from
+    /// `self.position` onwards.
     fn seek(&mut self, byte: &[u8]) {
         while !self.is_at_end() && byte != [self.current_byte()] {
             self.advance();

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -85,29 +85,7 @@ impl Scanner<'_> {
             b"<" => self.decide_token_type(Less, (LessEqual, b"=")),
             b"/" => self.decide_token_type(Slash, (SlashSlash, b"/")),
             [digit] if digit.is_ascii_digit() => self.treat_number(),
-            &[a] if a.is_ascii_alphabetic() || a == b'_' => {
-                let range = self.measure_word();
-                let word = &self.bytes[range];
-                match word {
-                    b"and" => Keyword(token::Keyword::And),
-                    b"class" => Keyword(token::Keyword::Class),
-                    b"else" => Keyword(token::Keyword::Else),
-                    b"false" => Keyword(token::Keyword::False),
-                    b"for" => Keyword(token::Keyword::For),
-                    b"fun" => Keyword(token::Keyword::Fun),
-                    b"if" => Keyword(token::Keyword::If),
-                    b"nil" => Keyword(token::Keyword::Nil),
-                    b"or" => Keyword(token::Keyword::Or),
-                    b"print" => Keyword(token::Keyword::Print),
-                    b"return" => Keyword(token::Keyword::Return),
-                    b"super" => Keyword(token::Keyword::Super),
-                    b"this" => Keyword(token::Keyword::This),
-                    b"true" => Keyword(token::Keyword::True),
-                    b"var" => Keyword(token::Keyword::Var),
-                    b"while" => Keyword(token::Keyword::While),
-                    bytes => Type::Identifier(String::from_utf8(bytes.to_vec()).unwrap()),
-                }
-            }
+            &[a] if a.is_ascii_alphabetic() || a == b'_' => self.treat_word(),
             _ => todo!("Unexpected lexeme {:#?}", std::str::from_utf8(&[self.current_byte()])),
         }
     }
@@ -133,6 +111,32 @@ impl Scanner<'_> {
         } else {
             let n = number.unwrap().parse::<i32>().unwrap();
             Type::NumberLiteral(token::NumberLiteral::Integer(n))
+        }
+    }
+
+    fn treat_word(&mut self) -> Type {
+        use Type::Keyword;
+
+        let range = self.measure_word();
+        let word = &self.bytes[range];
+        match word {
+            b"and" => Keyword(token::Keyword::And),
+            b"class" => Keyword(token::Keyword::Class),
+            b"else" => Keyword(token::Keyword::Else),
+            b"false" => Keyword(token::Keyword::False),
+            b"for" => Keyword(token::Keyword::For),
+            b"fun" => Keyword(token::Keyword::Fun),
+            b"if" => Keyword(token::Keyword::If),
+            b"nil" => Keyword(token::Keyword::Nil),
+            b"or" => Keyword(token::Keyword::Or),
+            b"print" => Keyword(token::Keyword::Print),
+            b"return" => Keyword(token::Keyword::Return),
+            b"super" => Keyword(token::Keyword::Super),
+            b"this" => Keyword(token::Keyword::This),
+            b"true" => Keyword(token::Keyword::True),
+            b"var" => Keyword(token::Keyword::Var),
+            b"while" => Keyword(token::Keyword::While),
+            bytes => Type::Identifier(String::from_utf8(bytes.to_vec()).unwrap()),
         }
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,6 +1,6 @@
 mod token;
 
-use std::ops::{Range, RangeInclusive};
+use std::ops::RangeInclusive;
 
 use token::{Token, Type};
 
@@ -152,17 +152,19 @@ impl Scanner<'_> {
         start+1..=end_inclusive-1  // Trims both quotes
     }
 
-    fn measure_number(&mut self) -> (bool, Range<usize>) {
+    fn measure_number(&mut self) -> (bool, RangeInclusive<usize>) {
         let mut is_float = false;
         let start = self.position;
         self.advance_until_not_ascii_digit();
         if !self.is_at_end() && &[self.current_byte()] == b"." {
-            self.advance();
+            self.advance();  // Skips the `.`
             self.advance_until_not_ascii_digit();
             is_float = true;
         }
-        let end_exclusive = self.position;
-        let range = start..end_exclusive;
+
+        self.position -= 1;  // `advance_until_not_ascii_digit` stops **after** the number
+        let end_inclusive = self.position;
+        let range = start..=end_inclusive;
 
         (is_float, range)
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -413,26 +413,84 @@ mod tests {
         }
     }
 
-    mod integers {
+    mod numbers {
         use super::*;
 
-        #[test]
-        fn scans_lone_integers() {
-            let code = "123";
+        mod integers {
+            use super::*;
 
-            let tokens = Scanner::new(code).scan_tokens();
+            #[test]
+            fn scans_lone_integers() {
+                let code = "123";
 
-            assert_eq!(
-                tokens,
-                &[
-                    Token { r#type: NumberLiteral(NumberLiteral::Integer(123)) },
-                ],
-            )
+                let tokens = Scanner::new(code).scan_tokens();
+
+                assert_eq!(
+                    tokens,
+                    &[
+                        Token { r#type: NumberLiteral(NumberLiteral::Integer(123)) },
+                    ],
+                )
+            }
+
+            #[test]
+            fn scans_integers() {
+                let code = "0 + 123 - 1";
+
+                let tokens = Scanner::new(code).scan_tokens();
+
+                assert_eq!(
+                    tokens,
+                    &[
+                        Token { r#type: NumberLiteral(NumberLiteral::Integer(0)) },
+                        Token { r#type: Plus },
+                        Token { r#type: NumberLiteral(NumberLiteral::Integer(123)) },
+                        Token { r#type: Minus },
+                        Token { r#type: NumberLiteral(NumberLiteral::Integer(1)) },
+                    ],
+                )
+            }
+        }
+
+        mod floats {
+            use super::*;
+
+            #[test]
+            fn scans_lone_floats() {
+                let code = "12.3";
+
+                let tokens = Scanner::new(code).scan_tokens();
+
+                assert_eq!(
+                    tokens,
+                    &[
+                        Token { r#type: NumberLiteral(NumberLiteral::Float(12.3)) },
+                    ],
+                )
+            }
+
+            #[test]
+            fn scans_floats() {
+                let code = "0 + 12.3 / 5";
+
+                let tokens = Scanner::new(code).scan_tokens();
+
+                assert_eq!(
+                    tokens,
+                    &[
+                        Token { r#type: NumberLiteral(NumberLiteral::Integer(0)) },
+                        Token { r#type: Plus },
+                        Token { r#type: NumberLiteral(NumberLiteral::Float(12.3)) },
+                        Token { r#type: Slash },
+                        Token { r#type: NumberLiteral(NumberLiteral::Integer(5)) },
+                    ],
+                )
+            }
         }
 
         #[test]
-        fn scans_integers() {
-            let code = "0 + 123 - 1";
+        fn scans_numbers_without_whitespace() {
+            let code = "0+12.3!=5.77";
 
             let tokens = Scanner::new(code).scan_tokens();
 
@@ -441,45 +499,9 @@ mod tests {
                 &[
                     Token { r#type: NumberLiteral(NumberLiteral::Integer(0)) },
                     Token { r#type: Plus },
-                    Token { r#type: NumberLiteral(NumberLiteral::Integer(123)) },
-                    Token { r#type: Minus },
-                    Token { r#type: NumberLiteral(NumberLiteral::Integer(1)) },
-                ],
-            )
-        }
-    }
-
-    mod floats {
-        use super::*;
-
-        #[test]
-        fn scans_lone_floats() {
-            let code = "12.3";
-
-            let tokens = Scanner::new(code).scan_tokens();
-
-            assert_eq!(
-                tokens,
-                &[
                     Token { r#type: NumberLiteral(NumberLiteral::Float(12.3)) },
-                ],
-            )
-        }
-
-        #[test]
-        fn scans_floats() {
-            let code = "0 + 12.3 / 5";
-
-            let tokens = Scanner::new(code).scan_tokens();
-
-            assert_eq!(
-                tokens,
-                &[
-                    Token { r#type: NumberLiteral(NumberLiteral::Integer(0)) },
-                    Token { r#type: Plus },
-                    Token { r#type: NumberLiteral(NumberLiteral::Float(12.3)) },
-                    Token { r#type: Slash },
-                    Token { r#type: NumberLiteral(NumberLiteral::Integer(5)) },
+                    Token { r#type: BangEqual },
+                    Token { r#type: NumberLiteral(NumberLiteral::Float(5.77)) },
                 ],
             )
         }

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -14,32 +14,6 @@ impl std::fmt::Debug for Token {
     }
 }
 
-impl Token {
-    pub fn is_compound(&self) -> bool {
-        match self.r#type {
-            Type::LeftParen
-            | Type::RightParen
-            | Type::LeftBrace
-            | Type::RightBrace
-            | Type::Comma
-            | Type::Dot
-            | Type::Minus
-            | Type::Plus
-            | Type::Semicolon
-            | Type::Star
-            | Type::Equal
-            | Type::Bang
-            | Type::Greater
-            | Type::Less
-            | Type::StringLiteral(_)      // Not exactly...
-            | Type::NumberLiteral(_)      // Not exactly...
-            | Type::Keyword(_) => false,  // Not exactly...
-
-            _ => true,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq)]
 pub(crate) enum Type {
     LeftParen,

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -46,6 +46,7 @@ pub(crate) enum Type {
     Error(Error),
 
     Keyword(Keyword),
+    Identifier(String),
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/interpreter/token.rs
+++ b/src/interpreter/token.rs
@@ -31,8 +31,9 @@ impl Token {
             | Type::Bang
             | Type::Greater
             | Type::Less
-            | Type::StringLiteral(_)            // Not exactly...
-            | Type::NumberLiteral(_) => false,  // Not exactly...
+            | Type::StringLiteral(_)      // Not exactly...
+            | Type::NumberLiteral(_)      // Not exactly...
+            | Type::Keyword(_) => false,  // Not exactly...
 
             _ => true,
         }
@@ -69,12 +70,34 @@ pub(crate) enum Type {
     NumberLiteral(NumberLiteral),
 
     Error(Error),
+
+    Keyword(Keyword),
 }
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum NumberLiteral {
     Integer(i32),
     Float(f64),
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Keyword {
+    And,
+    Class,
+    Else,
+    False,
+    For,
+    Fun,
+    If,
+    Nil,
+    Or,
+    Print,
+    Return,
+    Super,
+    This,
+    True,
+    Var,
+    While,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
The scanner will be able to scan user-defined identifiers and every keyword.

Even though the book says that keywords are identifiers, I preferred to differentiate them to simplify the `Type` enum.

Any word that doesn't match a keyword will be considered a user-defined identifier.

When creating a test for this, I noticed the scanner always consumed the character just after a number.
For instance `5;` never scanned the `;`, but correctly scanned `5`.
I fixed it in this PR.

The docstring for `Scanner::seek()` was incorrect, so I updated it.

I also removed the `Token::is_compound()` function, as I wasn't liking literals and identifiers not being considered compound tokens.
To avoid scanning the remaining character of two-character lexemes, I simply call `Scanner::advance()` after detecting them in `Scanner::decide_token_type()`.